### PR TITLE
op3(t): add missing ecc props

### DIFF
--- a/system.prop
+++ b/system.prop
@@ -111,6 +111,8 @@ persist.vendor.radio.data_con_rprt=1
 persist.vendor.radio.custom_ecc=1
 persist.vendor.radio.sib16_support=1
 persist.radio.aosp_usr_pref_sel=true
+ril.ecclist=112,911,999,*911,#911
+ril.ecclist1=911,112,999,*911,#911,991,994
 
 # RmNet Data
 persist.rmnet.data.enable=true


### PR DESCRIPTION
even if those values seem to be ignored currently
add them to be better save then sorry if they ever
are used after a blob update

Change-Id: I2c14ad3f26bb6e4447b8284d6f9afbd7b9c94fc5